### PR TITLE
feat: 데스크탑 버전 레이아웃 변경

### DIFF
--- a/src/pages/DefaultPage/index.js
+++ b/src/pages/DefaultPage/index.js
@@ -3,11 +3,12 @@ import DefaultPageDescription from '../../components/DefaultPageDescription';
 import DefaultPageInputs from '../../components/DefaultPageInputs';
 import gradation from '../../assets/images/gradation_bg.jpg';
 import styled from 'styled-components';
+import { flexCustom } from '../../styles/theme';
 
 const DefaultPage = () => {
   return (
     <MainWrapper>
-      <MainBackground src={gradation} alt={'background'} />
+      <MainBackgroundImg src={gradation} alt="background" />
       <DefaultPageDescription />
       <DefaultPageInputs border />
     </MainWrapper>
@@ -17,18 +18,17 @@ const DefaultPage = () => {
 export default DefaultPage;
 
 const MainWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
+  ${flexCustom('column', 'center', 'flex-start')}
 
   height: 100vh;
   width: 100vw;
-  // max-width: 390px;
 
   @media (max-width: 400px) {
     width: 100%;
   }
 `;
 
-const MainBackground = styled.img`
+const MainBackgroundImg = styled.img`
+  max-width: 400px;
   opacity: 0.75;
 `;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,11 +2,7 @@ import React from 'react';
 import DefaultPage from './DefaultPage';
 
 const Main = () => {
-  return (
-    <>
-      <DefaultPage />
-    </>
-  );
+  return <DefaultPage />;
 };
 
 export default Main;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,4 +1,4 @@
-// import styled, { css } from 'styled-components';
+import { css } from 'styled-components';
 
 const theme = {
   white: '#ffffff',
@@ -12,5 +12,12 @@ const theme = {
   fontGrey: '#acadb5',
   fontNavy: '#45597a',
 };
+
+export const flexCustom = (flexDirection, alignItems, justifyContent) => css`
+  display: flex;
+  flex-direction: ${flexDirection || 'initial'};
+  align-items: ${alignItems || 'center'};
+  justify-content: ${justifyContent || 'center'};
+`;
 
 export default theme;


### PR DESCRIPTION
- 데스크탑 버전에서 배경 이미지 깨지지 않게 max-width 설정 및 가운데 정렬
- theme.js에 flexCustom 함수 추가